### PR TITLE
Fix npm 1.3.5 warning about repositories being plural

### DIFF
--- a/examples/zepto.js
+++ b/examples/zepto.js
@@ -1,0 +1,53 @@
+Eve.register('rot13', function(ns) { 
+
+	function rot13(e) {
+		var el = $(e.target);
+		el.text(el.text().replace(/[a-zA-Z]/g, function(c) {
+			return String.fromCharCode((c <= "Z" ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
+		}));
+	};
+	
+	//The event simulation code isn't happy with jQuery's mouseenter/leave.
+	this.listen('ul li', 'mouseover', rot13);
+	this.listen('ul li', 'mouseout', rot13);
+
+});
+
+Eve.register('active', function(ns) { 
+
+	this.listen('li', 'click', function(e) {
+		this.find('.active').removeClass('active');
+		this.find(e.target).addClass('active');
+	});
+
+});
+
+Eve.attach('active', '.list-module ul');
+Eve.attach('rot13',	 '.list-module');
+
+Eve.scope('.other-module', function() {
+	this.listen('ul', 'click', function(e) {
+		console.log("Inner module click!");
+	});
+	this.attach('rot13');
+});
+
+Eve.scope("#outer_scope", function() {
+	
+	this.scope('.inner_scope', function() {
+		
+		this.listen('a', 'click', function(e) {
+			$(e.target).addClass('affected');
+		});
+		
+		this.scope('#another_scope', function() {
+			
+			this.listen('span', 'click', function(e) {
+				$(e.target).addClass('affected');
+			});
+			
+		});
+		
+	});
+	
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"scripts":{
 		"test": "scripts/test.sh"
 	},
-	"repositories": [
+	"repository": [
 		{
 			"type": "git",
 			"url": "https://github.com/Yuffster/Eve.js"

--- a/src/eve.js
+++ b/src/eve.js
@@ -34,7 +34,7 @@ function detectFramework() {
 
 	if (_framework) return _framework;
 
-	var fws = ['jQuery', 'MooTools', 'YUI', 'Prototype', 'dojo'];
+	var fws = ['Zepto', 'jQuery', 'MooTools', 'YUI', 'Prototype', 'dojo'];
 	for (var i = 0; i<= fws.length; i++) {
 		if (window[fws[i]]) {
 			Eve.setFramework(fws[i]);
@@ -93,6 +93,7 @@ ns.Eve = {
 	setFramework: function(fw) {
 		_framework = (fw+"").toLowerCase();
 		if (_framework=='jquery') $ = jQuery; //No-conflict compat.
+		if (_framework=='zepto') $ = Zepto; //No-conflict compat.
 	},
 
 	debug: function(moduleName) {
@@ -174,14 +175,14 @@ var Scope = {
 				dbug(name, sel+':'+event);
 				obj.event = e;
 				if (using("MooTools")) { e.target = t; }
-				if (using("jQuery"))   { e.target = e.currentTarget; }
+				if (using("jQuery") || using("Zepto"))   { e.target = e.currentTarget; }
 				if (using("dojo"))     { e.target = e.explicitOriginalTarget; }
 				handler.apply(obj, arguments);
 			};
 
 		//JavaScript framework development is so much easier when you let some
 		//other framework do most of the work.
-		if (using("jQuery")) {
+		if (using("jQuery") || using("Zepto")) {
 			$(scope).delegate(sel, event, fun);
 		} else if (using('MooTools')) {
 			//I really hate the MooTools event delegation syntax.
@@ -205,9 +206,11 @@ var Scope = {
 		//event.
 		var t  = (this.event) ? this.event.target : document.body;
 		if (using('jQuery')) t = jQuery(t);
+		if (using('Zepto')) t = Zepto(t);
 		if (_dom) t = _dom(t);
 		var map = {
 			jQuery: ['is', 'parents', 'find'],
+			Zepto: ['is', 'parents', 'find'],
 			MooTools: ['match', 'getParent', 'getElements'],
 			Prototype: ['match', 'up', 'select'],
 			YUI: ['test', 'ancestor', 'all'],

--- a/tests/run_tests.html
+++ b/tests/run_tests.html
@@ -160,6 +160,7 @@
 		<navigation id="framework-select">
 			<h1><a href="http://evejs.com">Eve.js Test Runner</a></h1>
 			<ul id="framework-list">
+				<li id="fw-zepto"><a href="?runner=zepto">Zepto</a></li>
 				<li id="fw-jquery"><a href="?runner=jquery">jQuery</a></li>
 				<li id="fw-mootools"><a href="?runner=mootools">MooTools</a></li>
 				<li id="fw-prototype"><a href="?runner=prototype">Prototype</a></li>

--- a/tests/test_client.js
+++ b/tests/test_client.js
@@ -5,6 +5,7 @@
 		eve       : "../src/eve.js",
 		'eve.min' : "../eve.min.js",
 		mootools  : "http://ajax.googleapis.com/ajax/libs/mootools/1.4.5/mootools-yui-compressed.js",
+		zepto	  : "http://cdnjs.cloudflare.com/ajax/libs/zepto/1.0/zepto.min.js",
 		jquery	  : "http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js",
 		dojo	  : "http://ajax.googleapis.com/ajax/libs/dojo/1.8.0/dojo/dojo.js",
 		yui		  : "http://yui.yahooapis.com/3.6.0/build/yui/yui-min.js",


### PR DESCRIPTION
Running "npm install" I got the following warning:

```
npm WARN package.json eve.js@0.8.4 'repositories' (plural) Not supported.
npm WARN package.json Please pick one as the 'repository' field
```

This tiny tweak fixes it.
